### PR TITLE
Avoid deleting tag files for records added to the cache during clean.

### DIFF
--- a/File.php
+++ b/File.php
@@ -469,6 +469,14 @@ class Cm_Cache_Backend_File extends Zend_Cache_Backend_File
         if (!is_dir($dir)) {
             return false;
         }
+        if ($mode == 'all' && $dir === $this->_options['cache_dir']) {
+            $glob = glob($this->_tagFile('*'));
+            if ($glob !== false) {
+                foreach ($glob as $tagFile) {
+                    @unlink($tagFile);
+                }
+            }
+        }
         $result = true;
         $glob = @glob($dir . $this->_options['file_name_prefix'] . '--*');
         if ($glob === false) {
@@ -509,11 +517,6 @@ class Cm_Cache_Backend_File extends Zend_Cache_Backend_File
                     // if mode=='all', we try to drop the structure too
                     @rmdir($file);
                 }
-            }
-        }
-        if ($mode == 'all') {
-            foreach (glob($this->_tagFile('*')) as $tagFile) {
-                @unlink($tagFile);
             }
         }
         return $result;

--- a/File.php
+++ b/File.php
@@ -434,7 +434,7 @@ class Cm_Cache_Backend_File extends Zend_Cache_Backend_File
         $partsArray = array();
         $root = $this->_options['cache_dir'];
         $prefix = $this->_options['file_name_prefix'];
-        if ($this->_options['hashed_directory_level']>0) {
+        if ($this->_options['hashed_directory_level'] > 0) {
             $root .= $prefix . '--' . substr(md5($id), -$this->_options['hashed_directory_level']) . DIRECTORY_SEPARATOR;
             $partsArray[] = $root;
         }
@@ -740,7 +740,7 @@ class Cm_Cache_Backend_File extends Zend_Cache_Backend_File
      */
     protected function _recursiveMkdirAndChmod($id)
     {
-        if ($this->_options['hashed_directory_level'] <=0) {
+        if ($this->_options['hashed_directory_level'] <= 0) {
             return true;
         }
         $partsArray = $this->_path($id, true);


### PR DESCRIPTION
During a clean operation, if new data is added to the cache and is stored in a path that has already been cleaned, then the new data file will remain after the clean, but its tags will be deleted, because tag files are deleted last.  The result is that the data can be fetched from the cache, but cannot be cleaned by tag. This PR deletes the tag files before the data files in order to avoid that problem.