### PR TITLE
Add global_lock option to prevent reading/writing during cache cleaning.

### DIFF
--- a/File.php
+++ b/File.php
@@ -42,7 +42,7 @@ class Cm_Cache_Backend_File extends Zend_Cache_Backend_File
         'cache_dir' => null,               // Path to cache files
         'file_name_prefix' => 'cm',        // Prefix for cache directories created
         'file_locking' => true,            // Best to keep enabled
-        'global_locking' => true,          // Best to keep enabled
+        'global_locking' => false,          // Disabled by default, enable to eliminate possible race conditions
         'read_control' => false,           // Use a checksum to detect corrupt data
         'read_control_type' => 'crc32',    // If read_control is enabled, which checksum algorithm to use
         'hashed_directory_level' => 2,     // How many characters should be used to create sub-directories

--- a/tests/FileBackendTest.php
+++ b/tests/FileBackendTest.php
@@ -94,6 +94,7 @@ class FileBackendTest extends \CommonExtendedBackend
         $this->_instance->setOption('cache_dir', '/foo/bar/lfjlqsdjfklsqd/');
         $res = $this->_instance->save('data to cache', 'foo', array('tag1', 'tag2'));
         $this->assertFalse($res);
+        $this->assertEquals('mkdir(): No such file or directory', error_get_last()['message']);
     }
 
     public function testSaveWithNullLifeTime2()


### PR DESCRIPTION
As observed in #39 there are possibilities for race conditions when cache is being cleaned and records are being written. This adds a global lock around all operations such that cleaning always gets an exclusive lock while everything else (load, save, remove, etc) only gets a shared lock. In this way, it should be nigh impossible to get any cache tag corruption due to reads/writes happening simultaneously to cleaning.